### PR TITLE
Remove 'version: v1beta1' from CRD Spec

### DIFF
--- a/stable/kms-secrets/templates/crd.yaml
+++ b/stable/kms-secrets/templates/crd.yaml
@@ -13,7 +13,6 @@ spec:
     plural: kmssecrets
     singular: kmssecret
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true


### PR DESCRIPTION
The 'v1' API does not have the 'version' key at all. This causes the CRD install to
fail with:

```
"unknown field "version" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec"
```

See the Spec at https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#customresourcedefinitionspec-v1-apiextensions-k8s-io