### PR TITLE
feat(kms-secrets): allow overriding the resources, tolerations and nodeselector

### DIFF
--- a/stable/kms-secrets/Chart.yaml
+++ b/stable/kms-secrets/Chart.yaml
@@ -2,6 +2,5 @@ apiVersion: v2
 name: kms-secrets
 description: A Helm chart for kms-secrets
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.4.0
-

--- a/stable/kms-secrets/README.md
+++ b/stable/kms-secrets/README.md
@@ -23,6 +23,9 @@ Parameter | Description | Default
 | `namespace` | Namespace which you want to install | `kube-system` |
 | `image.repository` | The image repository to pull from | `ghcr.io/h3poteto/kms-secrets` |
 | `image.tag` | The image tag to pull | `0.1.4` |
+| `tolerations` | A list of Node Tolerations | `[]` |
+| `nodeSelector` | Node Selector for the pods | `{}` |
+| `resources` | Resources for the `manager` container | `{ limits: { cpu: 100m, memory: 30Mi }, requests: { cpu: 100m, memory: 20Mi }` |
 | `rbac.create` | If true, create RBAC resources | `true` |
 | `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default` |
 | `rbac.serviceAccount.annotations` | Annotations to add to the Service Account (ignore if rbac.create=false) | `{}` |

--- a/stable/kms-secrets/templates/manager.yaml
+++ b/stable/kms-secrets/templates/manager.yaml
@@ -18,6 +18,14 @@ spec:
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kms-secrets.serviceAccountName" . }}
       securityContext:
         # We have to specify groupID to mount IRSA volumes.
@@ -30,11 +38,8 @@ spec:
         - --enable-leader-election
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: manager
+        {{- with .Values.resources }}
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: 10

--- a/stable/kms-secrets/values.yaml
+++ b/stable/kms-secrets/values.yaml
@@ -4,6 +4,17 @@ image:
   repository: ghcr.io/h3poteto/kms-secrets
   tag: 0.4.0
 
+resources:
+  limits:
+    cpu: 100m
+    memory: 30Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+tolerations: {}
+nodeSelector: {}
+
 rbac:
   create: true
   serviceAccountName: ""


### PR DESCRIPTION
We'd like to migrate away from using manually managed manifest files to run the KMS controller and use the helm chart, but it's missing some critical settings for us. This PR maintains the current behavior, but allows for overriding the behaviors for `resources`, `tolerations` and `nodeSelector` fields.

Eg diff:
```diff
% helm template . > new && diff -b -u  orig new
--- orig	2023-11-30 15:26:49
+++ new	2023-11-30 15:27:29
@@ -220,6 +220,8 @@
       labels:
         control-plane: controller-manager
     spec:
+      nodeSelector:
+        foo: bar
       serviceAccountName: release-name-manager
       securityContext:
         # We have to specify groupID to mount IRSA volumes.
@@ -234,7 +236,7 @@
         name: manager
         resources:
           limits:
-            cpu: 100m
+            cpu: 1000m
             memory: 30Mi
           requests:
             cpu: 100m
```